### PR TITLE
Fix broken link in "Step 3.5: Collections and iterators"

### DIFF
--- a/3_ecosystem/3_5_collections/README.md
+++ b/3_ecosystem/3_5_collections/README.md
@@ -116,4 +116,4 @@ Prove your implementation correctness with tests.
 [14]: https://github.com/instrumentisto/stjepang.github.io/blob/master/_posts/2019-01-29-lock-free-rust-crossbeam-in-2019.md
 [15_1]: https://hypirion.com/musings/understanding-persistent-vector-pt-1
 [15_2]: https://hypirion.com/musings/understanding-persistent-vector-pt-2
-[15_2]: https://hypirion.com/musings/understanding-persistent-vector-pt-3
+[15_3]: https://hypirion.com/musings/understanding-persistent-vector-pt-3


### PR DESCRIPTION
## Synopsis

There's a broken link, caused by one link URL having the same ID as another one, resulting in a link tag pointing to a nonexistent URL ID.

## Solution

I fixed the URL's ID.