### PR TITLE
Remove mentoring mentions from workflow

### DIFF
--- a/0_basics/README.md
+++ b/0_basics/README.md
@@ -28,8 +28,6 @@ After completing these steps, you should be able to answer (and understand why) 
 - What are lifetimes? Which problems do they solve? Which benefits do they give?
 - Is [Rust] OOP language? Is it possible to use SOLID/GRASP? Does it have an inheritance?
 
-After you're done notify your lead in an appropriate PR (pull request), and he will exam what you have learned.
-
 _Additional_ articles, which may help to understand the above topic better:
 - [Chris Morgan: Rust ownership, the hard way][1]
 - [Adolfo Ochagavía: You are holding it wrong][12]

--- a/README.md
+++ b/README.md
@@ -189,5 +189,4 @@ Each step must be performed as a separate [PR (pull request)][PR] with an approp
 [1]: https://github.com/instrumentisto/rust-incubator/generate
 [2]: https://github.com/instrumentisto/rust-incubator/subscription
 [11]: https://help.github.com/en/articles/creating-a-repository-from-a-template
-[12]: https://help.github.com/en/articles/inviting-collaborators-to-a-personal-repository
 [13]: https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This project represents a hard-way step-by-step [Rust] learning course from lang
 
 ### Schedule
 
-Each step must be performed as a separate [PR (pull request)][PR] with an appropriate name and checkmarked here in README's schedule after completion. Each step is a [Cargo workspace member][13], so you can run/test it from the project root (i.e. `cargo run -p step_1_8`). __Consider to use [rustfmt] and [Clippy] when you're writing [Rust] code.__
+Each step must be performed as a separate [PR (pull request)][PR] with an appropriate name and check-marked here in README's schedule after completion. Each step is a [Cargo workspace member][13], so you can run/test it from the project root (i.e. `cargo run -p step_1_8`). __Consider to use [rustfmt] and [Clippy] when you're writing [Rust] code.__
 
 - [ ] [0. Become familiar with Rust basics][Step 0] (3 days)
 - [ ] [1. Concepts][Step 1] (2 days, after all sub-steps)

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ This project represents a hard-way step-by-step [Rust] learning course from lang
 
 ### Before you start
 
-1. [Create][1] a new [GitHub repository] for yourself using this one [as template][11].
-2. [Invite as a collaborator][12] of your repository the person you want to review your lessons (mentor or lead).
+[Create][1] a new [GitHub repository] for yourself using this one [as template][11].
 
 > __NOTE__: __This learning course is constantly improving and evolving over time.__ 
 >
@@ -68,10 +67,6 @@ This project represents a hard-way step-by-step [Rust] learning course from lang
 ### Schedule
 
 Each step must be performed as a separate [PR (pull request)][PR] with an appropriate name and checkmarked here in README's schedule after completion. Each step is a [Cargo workspace member][13], so you can run/test it from the project root (i.e. `cargo run -p step_1_8`). __Consider to use [rustfmt] and [Clippy] when you're writing [Rust] code.__
-
-Each step has the estimated time for completion. If any deeper investigation on step's theme is needed by you, then it's on your own.
-
-Do not hesitate to ask your mentor/lead with questions, however you won't receive any concrete answer, but rather a direction for your own investigation. _Mentor/Lead is the one who asks questions here, demanding concrete and complete answers._
 
 - [ ] [0. Become familiar with Rust basics][Step 0] (3 days)
 - [ ] [1. Concepts][Step 1] (2 days, after all sub-steps)


### PR DESCRIPTION
## Synopsis

Currently, the Rust Incubator documentation outlines a workflow involving mentoring, but this doesn't always align with the actual process. To address potential misunderstandings, this PR eliminates any references to mentoring from the workflow.

## Solution

Remove sections of the workflow that rely on a lead or mentor.