### PR TITLE
docs: fix some grammar issues in root, Step 0, Step 1.1, and Step 1.2 READMEs

### DIFF
--- a/0_basics/README.md
+++ b/0_basics/README.md
@@ -3,30 +3,30 @@ Step 0: Become familiar with Rust basics
 
 __Estimated time__: 3 days
 
-Read through [Rust Book], [Rust FAQ], and become familiar with basic [Rust] concepts, syntax, memory model, type and module systems.
+Read through [the Rust Book][Rust Book], [Rust FAQ], and become familiar with basic [Rust] concepts, syntax, the memory model, and the type and module systems.
 
-Polish your familiarity by completing [Rust By Example] and [rustlings].
+Polish your familiarity by completing [Rust By Example] and [Rustlings][rustlings].
 
-Read through [Cargo Book] and become familiar with [Cargo] and its workspaces.
+Read through [the Cargo Book][Cargo Book] and become familiar with [Cargo] and its workspaces.
 
 After completing these steps, you should be able to answer (and understand why) the following questions:
-- What memory model [Rust] has? Is it single-threaded or multiple-threaded? Is it synchronous or asynchronous?
-- What runtime [Rust] has? Does it use a GC (garbage collector)?
-- What statically typing means? What is a benefit of using it?
+- What memory model does [Rust] have? Is it single-threaded or multiple-threaded? Is it synchronous or asynchronous?
+- What runtime does [Rust] have? Does it use a GC (garbage collector)?
+- What does static typing mean? What is a benefit of using it?
 - What are generics and parametric polymorphism? Which problems do they solve?
-- What are traits? How are they used? How do they compare to interfaces? What are an auto trait and a blanket impl? What is a marker trait?
-- What are static and dynamic dispatches? Which should I use, and when?
-- What is a crate and what is a module in Rust? How do they differ? How are the used?
+- What are traits? How are they used? How do they compare to interfaces? What are auto traits and blanket impls? What is a marker trait?
+- What are static and dynamic dispatch? Which should you use, and when?
+- What is a crate and what is a module in [Rust]? How do they differ? How are they used?
 - What are move semantics? What are borrowing rules? What is the benefit of using them?
 - What is immutability? What is the benefit of using it?
 - What is cloning? What is copying? How do they compare?
 - What is RAII? How is it implemented in [Rust]? What is the benefit of using it?
 - What is an iterator? What is a collection? How do they differ? How are they used?
-- What are macros? Which problems do they solve? What is the difference between declarative and procedural macro?
-- How code is tested in [Rust]? Where should you put tests and why?
-- Why [Rust] has `&str` and `String` types? How do they differ? When should you use them?
+- What are macros? Which problems do they solve? What is the difference between declarative and procedural macros?
+- How is code tested in [Rust]? Where should you put tests and why?
+- Why does [Rust] have `&str` and `String` types? How do they differ? When should you use them?
 - What are lifetimes? Which problems do they solve? Which benefits do they give?
-- Is [Rust] OOP language? Is it possible to use SOLID/GRASP? Does it have an inheritance?
+- Is [Rust] an OOP language? Is it possible to use SOLID/GRASP? Does it have inheritance?
 
 _Additional_ articles, which may help to understand the above topic better:
 - [Chris Morgan: Rust ownership, the hard way][1]

--- a/1_concepts/1_1_default_clone_copy/README.md
+++ b/1_concepts/1_1_default_clone_copy/README.md
@@ -8,11 +8,11 @@ __Estimated time__: 1 day
 
 ## Default values
 
-[Rust] has a standard way to deal with default values of a type via [`Default`] trait. Read through [its official docs][`Default`] to understand the design.
+[Rust] has a standard way to deal with default values of a type via the [`Default`] trait. Read through [its official docs][`Default`] to understand the design.
 
-It can be auto-derived, but only for a `struct` whose all members have [`Default`] implementations. It is implemented for a great many types in the standard library, and also used in a surprising number of places. So if your type has a value that can be construed as being "default", it is a good idea to implement this trait.
+It can be auto-derived, but only for a `struct` whose members all have [`Default`] implementations. It is implemented for a great many types in the standard library, and also used in a surprising number of places. So if your type has a value that can be construed as being "default", it is a good idea to implement this trait.
 
-If you're not enough with [std] deriving capabilities for [`Default`], consider to use [smart-default] crate. An example is quite self-explanatory:
+If you're not satisfied with [std] deriving capabilities for [`Default`], consider using the [smart-default] crate. An example is quite self-explanatory:
 ```rust
 #[derive(SmartDefault)]
 enum Foo {
@@ -33,7 +33,7 @@ enum Foo {
 }
 ```
 
-A great thing that having a [`Default`] implementation you can instantiate your `struct` with only the non-default values and have all other fields filled with default values:
+A great thing is that with a [`Default`] implementation you can instantiate your `struct` with only the non-default values and have all other fields filled with default values:
 ```rust
 let x = Foo { bar: baz, ..Default::default() };
 ```
@@ -45,9 +45,9 @@ let x = Foo { bar: baz, ..Default::default() };
 
 By default, all types in [Rust] follow ['move semantics'][1].
 
-If you need a duplicate of a value, then its type should implement [`Clone`] trait (see [official docs][`Clone`]), and a duplicate is created by calling [`Clone`] methods __explicitly__. Cloning can be __either cheap or expensive__ operation depending on type semantics.
+If you need a duplicate of a value, then its type should implement [`Clone`] trait (see [official docs][`Clone`]), and a duplicate is created by calling [`Clone`] methods __explicitly__. Cloning can be __either a cheap or an expensive__ operation depending on type semantics.
 
-However, [`Copy`] marker trait (see [official docs][`Copy`]) enables 'copy semantics' for a type, so a value is __copied implicitly__ every time is passed. That's why copying must always perform a __simple bit-to-bit copy operation__.
+However, the [`Copy`] marker trait (see [official docs][`Copy`]) enables 'copy semantics' for a type, so a value is __copied implicitly__ every time it is passed. That's why copying must always perform a __simple bit-to-bit copy operation__.
 
 [Official `Copy` docs][`Copy`] are quite explanatory about which types _should_ be [`Copy`] and which types _cannot_:
 
@@ -57,7 +57,7 @@ However, [`Copy`] marker trait (see [official docs][`Copy`]) enables 'copy seman
 
 > Generally speaking, if your type can implement `Copy`, it should. Keep in mind, though, that implementing `Copy` is part of the public API of your type. If the type might become non-`Copy` in the future, it could be prudent to omit the `Copy` implementation now, to avoid a breaking API change.
 
-For better understanding the topic, read through:
+To better understand the topic, read through:
 - [Official `Clone` docs][`Clone`]
 - [Official `Copy` docs][`Copy`]
 - [HashRust: Moves, copies and clones in Rust][2]
@@ -76,7 +76,7 @@ For better understanding the topic, read through:
 ## Questions
 
 After completing everything above, you should be able to answer (and understand why) the following questions:
-- What purpose does [`Default`] trait serve in [Rust]?
+- What purpose does the [`Default`] trait serve in [Rust]?
 - What is `#[derive(Default)]` from `std` capable of? What does it wrong? Which are alternatives?
 - What does [`Clone`] mean semantically?
 - What does [`Copy`] mean semantically? How is it connected with [`Clone`]? Which limitations does it have and why?

--- a/1_concepts/1_2_box_pin/README.md
+++ b/1_concepts/1_2_box_pin/README.md
@@ -8,13 +8,13 @@ __Estimated time__: 1 day
 
 ## Boxing
 
-[`Box`] is a pointer that owns heap-allocated data. This is the most common and simples form of [heap] allocation in [Rust].
+[`Box`] is a pointer that owns heap-allocated data. This is the most common and simplest form of [heap] allocation in [Rust].
 
-It's more idiomatic to use references (`&T`/`&mut T`) for pointing to the data, however they often come with lifetimes complexity. [`Box`] allows to avoid this complexity at the cost of heap allocation.
+It's more idiomatic to use references (`&T`/`&mut T`) for pointing to the data, however they often come with lifetime complexity. [`Box`] allows to avoid this complexity at the cost of heap allocation.
 
-[`Box`] is also a way to go if an owned [slice] is needed, but is not intended to be resized. For example, `Box<str>`/`Box<[T]>` are often used instead `String`/`Vec<T>` in such cases.
+[`Box`] is also a way to go if an owned [slice] is needed, but is not intended to be resized. For example, `Box<str>`/`Box<[T]>` are often used instead of `String`/`Vec<T>` in such cases.
 
-For better understanding [`Box`] purpose, design, limitations and use cases read through:
+To better understand [`Box`]'s purpose, design, limitations, and use cases, read through:
 - [Rust Book: 15.1. Using Box to Point to Data on the Heap][1]
 - [Official `std::boxed` docs][`std::boxed`]
 - [Amos: What's in the box?][3]
@@ -25,7 +25,7 @@ For better understanding [`Box`] purpose, design, limitations and use cases read
 
 ## Pinning
 
-It is sometimes useful to have objects that are guaranteed to not move, in the sense that their placement in memory does not change, and can thus be relied upon. A prime example of such a scenario would be building self-referential structs, since moving an object with pointers to itself will invalidate them, which could cause undefined behavior.
+It is sometimes useful to have objects that are guaranteed to not move, in the sense that their placement in memory does not change, and can thus be relied upon. A prime example of such a scenario would be building self-referential structs, since moving an object with pointers to itself would invalidate them, which could cause undefined behavior.
 
 [`Pin<P>`][`Pin`] ensures that the pointee of any pointer type `P` has a stable location in memory, meaning it cannot be moved elsewhere and its memory cannot be deallocated until it gets dropped. We say that the pointee is "pinned".
 
@@ -33,7 +33,7 @@ However, many types are always freely movable, even when pinned, because they do
 
 Note, that pinning and [`Unpin`] only affect the pointed-to type `P::Target`, not the pointer type `P` itself that got wrapped in `Pin<P>`. For example, whether or not `Box<T>` is `Unpin` has no effect on the behavior of `Pin<Box<T>>` (here, `T` is the pointed-to type).
 
-For better understanding [`Pin`] purpose, design, limitations and use cases read through:
+To better understand [`Pin`]'s' purpose, design, limitations, and use cases, read through:
 - [Official `std::pin` docs][`std::pin`]
 - [Reddit: Pinned objects ELI5?][2]
 - [SoByte: Pin and Unpin in Rust][10]
@@ -93,7 +93,7 @@ After completing everything above, you should be able to answer (and understand 
 - What is [`Pin`] and why is it required? What guarantees does it provide? How does it fulfill them?
 - How does [`Unpin`] affect the [`Pin`]? What does it mean?
 - Is it allowed to move pinned data after the [`Pin`] dies? Why?
-- What is structural pinning? When it should be used and why?
+- What is structural pinning? When should it be used and why?
 - What is [`Pin`] projection? Why does it exist? How is it used?
 
 

--- a/1_concepts/1_2_box_pin/README.md
+++ b/1_concepts/1_2_box_pin/README.md
@@ -33,7 +33,7 @@ However, many types are always freely movable, even when pinned, because they do
 
 Note, that pinning and [`Unpin`] only affect the pointed-to type `P::Target`, not the pointer type `P` itself that got wrapped in `Pin<P>`. For example, whether or not `Box<T>` is `Unpin` has no effect on the behavior of `Pin<Box<T>>` (here, `T` is the pointed-to type).
 
-To better understand [`Pin`]'s' purpose, design, limitations, and use cases, read through:
+To better understand [`Pin`]'s purpose, design, limitations, and use cases, read through:
 - [Official `std::pin` docs][`std::pin`]
 - [Reddit: Pinned objects ELI5?][2]
 - [SoByte: Pin and Unpin in Rust][10]

--- a/1_concepts/1_3_rc_cell/README.md
+++ b/1_concepts/1_3_rc_cell/README.md
@@ -41,7 +41,7 @@ let y = Rc::clone(&a);  // but rather produces new reference to it
 
 The [`Rc`], however, __should be used wisely__ as __won't deallocate memory on references cycle__ which is exactly what a __memory leak__ is. [Rust] is unable to prevent memory leaks at compile time (though makes hard to produce them). If it's still required to have a references cycle, you should use a [`Weak`] smart pointer ("weak reference") in combination with [`Rc`]. [`Weak`] allows to break a references cycle as can refer to a value that has been dropped already (returns `None` in such case). 
 
-For better understanding [`Rc`]/[`Weak`] purpose, design, limitations and use cases read through:
+To better understand [`Rc`]/[`Weak`]'s purpose, design, limitations and use cases, read through:
 - [Rust Book: 15.4. Rc, the Reference Counted Smart Pointer][1]
 - [Rust Book: 15.6. Reference Cycles Can Leak Memory][2]
 - [Official `std::rc` docs][`std::rc`]
@@ -61,7 +61,7 @@ However, quite often there are situations where these rules are not flexible eno
 
 These containers __allow to overcome [Rust] borrowing rules and track borrows at runtime__ (so called "dynamic borrowing"), which, obviously, leads to less safe code as compile-time errors become runtime panics. That's why one should __use [`Cell`]/[`RefCell`] wisely and only as a last resort__.
 
-For better understanding [`Cell`]/[`RefCell`] purpose, design, limitations and use cases read through:
+To better understand [`Cell`]/[`RefCell`]'s purpose, design, limitations and use cases, read through:
 - [Rust Book: 15.5. RefCell and the Interior Mutability Pattern][3]
 - [Official `std::cell` docs][`std::cell`]
 - [Paul Dicker: Interior mutability patterns][6]

--- a/1_concepts/1_4_cow/README.md
+++ b/1_concepts/1_4_cow/README.md
@@ -28,7 +28,7 @@ fn describe(error: &Error) -> Cow<'static, str> {
 }
 ```
 
-For better understanding [`Cow`] purpose, design, limitations and use cases read through:
+To better understand [`Cow`]'s purpose, design, limitations and use cases, read through:
 - [Official `Cow` docs][`Cow`]
 - [Pascal Hertleif: The Secret Life of Cows][1]
 - [Yashodhan Joshi: Using `Cow` in Rust for efficient memory utilization][3]

--- a/1_concepts/1_5_convert_cast_deref/README.md
+++ b/1_concepts/1_5_convert_cast_deref/README.md
@@ -22,7 +22,7 @@ let small_num: u16 = big_num.try_into().expect("Value is too big");
 
 Note, that __all these traits consume ownership__ of a passed value. However, they [can be implemented for references too][2] if you're treating a reference as a value.
 
-For better understanding [`From`]/[`Into`] and [`TryFrom`]/[`TryInto`] purpose, design, limitations and use cases read through:
+To better understand [`From`]/[`Into`]'s and [`TryFrom`]/[`TryInto`]'s purpose, design, limitations and use cases, read through:
 - [Rust By Example: 6.1. From and Into][8]
 - [Official `From` docs][`From`]
 - [Official `Into` docs][`Into`]
@@ -43,7 +43,7 @@ let bytes: &[u8] = string.as_ref();
 
 [`AsRef`]/[`AsMut`] are commonly implemented for smart pointers to allow referring a data behind it via regular [Rust] references.
 
-For better understanding [`AsRef`]/[`AsMut`] purpose, design, limitations and use cases read through:
+To better understand [`AsRef`]/[`AsMut`]'s purpose, design, limitations and use cases, read through:
 - [Official `AsRef` docs][`AsRef`]
 - [Official `AsMut` docs][`AsMut`]
 - [Ricardo Martins: Convenient and idiomatic conversions in Rust][10]
@@ -72,7 +72,7 @@ So, as a conclusion:
 
 For example, it's natural for an `UserEmail` type to implement `Borrow<str>`, so it may be easily consumed in the code accepting `&str` (converted to `&str`), as they're semantically equivalent regarding `Hash`, `Eq` and `Ord`. And it's good for some execution `Context` to implement `AsRef<dyn Repository>`, so it can be extracted and used where needed, without using the whole `Context`.
 
-For better understanding [`AsRef`]/[`Borrow`] differences, read through:
+To better understand [`AsRef`]/[`Borrow`]'s difference, read through:
 - [Anup Jadhav: AsRef vs Borrow trait (ft. ChatGPT)][12]
 
 
@@ -137,7 +137,7 @@ let m = Box::new(String::from("Rust"));
 hello(&m);
 ```
 
-For better understanding [`Deref`] purpose, design, limitations and use cases read through:
+To better understand [`Deref`]'s purpose, design, limitations and use cases, read through:
 - [Rust Book: 15.2. Treating Smart Pointers Like Regular References with the Deref Trait][3]
 - [Official `Deref` docs][`Deref`]
 - [Tim McNamara: Explaining Rust’s Deref trait][13]

--- a/1_concepts/1_6_dispatch/README.md
+++ b/1_concepts/1_6_dispatch/README.md
@@ -11,7 +11,7 @@ __[Dynamic dispatch][2]__ (sometimes called "late binding") __happens at runtime
 
 You _have to_ use [dynamic dispatch][2] in situations where [type erasure][4] is required. If the problem can be solved with a [static dispatch][1] then you'd better to do so to avoid performance penalties. The most common example when you cannot use [static dispatch][1] and have to go with [dynamic dispatch][2] are _heterogeneous_ collections (where each item is potentially a different concrete type, but each one implements `MyTrait`).
 
-For better understanding [static][1] and [dynamic][2] dispatches purpose, design, limitations and use cases, read through the following articles:
+To better understand [static][1] and [dynamic][2] dispatches' purpose, design, limitations and use cases, read through:
 - [Rust Blog: Abstraction without overhead: traits in Rust][11]
 - [Joshleeb: Traits and Trait Objects in Rust][12]
 - [Rust Book: 17.2. Using Trait Objects That Allow for Values of Different Types][3]
@@ -37,7 +37,7 @@ The other reason to go with [static dispatch][1] is that except performance pena
 
 This can lead to quite tricky and non-obvious situations when writing code.
 
-For better understanding [object safety][5] purpose, design and limitations, read through the following articles:
+To better understand [object safety][5] purpose, design and limitations, read through:
 - [Rust Book: 17.2. Object Safety Is Required for Trait Objects][5]
 - [Rust Reference: 6.1. Traits: Object Safety][6]
 - [Nicholas Matsakis: Dyn async traits, part 2][17]

--- a/1_concepts/1_7_sized/README.md
+++ b/1_concepts/1_7_sized/README.md
@@ -7,7 +7,7 @@ Most types in [Rust] have a particular size, in bytes, that is knowable at compi
 
 All types with a constant size known at compile time in [Rust] implement [`Sized`] marker trait. And all type parameters (except `Self` in traits) have always an implicit bound of [`Sized`]. So, you should not bother about specifying [`Sized`] marker trait in code, usually.
 
-For better understanding [`Sized`] and `?Sized` purpose, design, limitations and use cases, read through the following articles:
+To better understand [`Sized`]'s and `?Sized`'s purpose, design, limitations and use cases, read through:
 - [Official `Sized` docs][`Sized`]
 - [Old Rust Book: 3.31. Unsized Types][4]
 - [Rust Forum: Trait Objects and the Sized Trait][5]

--- a/1_concepts/1_8_thread_safety/README.md
+++ b/1_concepts/1_8_thread_safety/README.md
@@ -5,7 +5,7 @@ __Estimated time__: 1 day
 
 [Rust] has [`Send`] and [`Sync`] marker traits which are fundamental for concurrency and thread safety story in [Rust] and represent one of [fearless concurrency][2] corner stones (which allow to [avoid data races][1] at compile time).
 
-For better understanding [`Send`]/[`Sync`] purpose, design, limitations and use cases, read through the following articles:
+To better understand [`Send`]/[`Sync`]'s purpose, design, limitations and use cases, read through:
 - [Official `Send` docs][`Send`]
 - [Official `Sync` docs][`Sync`]
 - [Rust Book: 16.4. Extensible Concurrency with the Sync and Send Traits][3]

--- a/1_concepts/1_9_phantom/README.md
+++ b/1_concepts/1_9_phantom/README.md
@@ -85,7 +85,7 @@ where
 }
 ```
 
-For better understanding [`PhantomData`] purpose, design, limitations and use cases, read through the following articles:
+To better understand [`PhantomData`]'s purpose, design, limitations and use cases, read through:
 - [Official `PhantomData` docs][`PhantomData`]
 - [Rust By Example: 14.9. Phantom type parameters][1]
 - [Rustonomicon: 3.10. PhantomData][2]
@@ -160,7 +160,7 @@ fn main() {
 }
 ```
 
-For more detailed explanation, read through the following articles:
+For more detailed explanation, read through:
 - [Official `ghost` crate docs][`ghost`]
 
 

--- a/2_idioms/2_1_type_safety/README.md
+++ b/2_idioms/2_1_type_safety/README.md
@@ -77,7 +77,7 @@ This is what is called ["newtype pattern"][1]. [Newtypes][1] are a zero-cost abs
 
 The downside of using [newtype pattern][1] is a necessity of writing _more boilerplate code_, because you should provide common traits implementations by yourself (like `Clone`, `Copy`, `From`/`Into`/`AsRef`/`AsMut`), as without them the type won't be ergonomic in use. However, most of them can be _derived automatically_ with `std` capabilities or third-party derive-crates (like [`derive_more`]), so the cost is acceptable in most cases. Furthermore, the excellent [`nutype`] crate pushes this idea even further, aiming to provide the best ergonomics for [newtype pattern][1] without compromising any guarantees it gives.
 
-For better understanding [newtype pattern][1], read through the following articles:
+To better understand [newtype pattern][1], read through:
 - [Rust Design Patterns: Newtype][1]
 - [Rust By Example: 14.7. New Type Idiom][2]
 - [Alexis King: Parse, don’t validate][7] ([ru][7_ru])
@@ -96,7 +96,7 @@ Not always, but _yes_ in some cases. One possible way is to use [typestates][3] 
 
 A real-world example of applying this idiom in [Rust] would be the awesome [`state_machine_future`] crate.
 
-For better understanding [typestates][3], read through the following articles:
+To better understand [typestates][3], read through:
 - [David Teller: Typestates in Rust][3]
 - [Cliff L. Biffle: The Typestate Pattern in Rust][5]
 - [Ana Hobden: Pretty State Machine Patterns in Rust][4]

--- a/2_idioms/2_2_mem_replace/README.md
+++ b/2_idioms/2_2_mem_replace/README.md
@@ -24,7 +24,7 @@ impl<T> Buffer<T> {
 }
 ```
 
-For better understanding [`mem::replace`], [`mem::swap`] and [`mem::take`] purpose, design, limitations and use cases, read through the following articles:
+To better understand [`mem::replace`]'s, [`mem::swap`]'s and [`mem::take`]'s purpose, design, limitations and use cases, read through:
 - [Official `mem::replace` docs][`mem::replace`]
 - [Official `mem::swap` docs][`mem::swap`]
 - [Official `mem::take` docs][`mem::take`]

--- a/2_idioms/2_5_exhaustivity/README.md
+++ b/2_idioms/2_5_exhaustivity/README.md
@@ -147,7 +147,7 @@ __`#[non_exhaustive]` attribute__, interestedly, __serves the very same purpose 
 
 Despite being opposite qualities, both exhaustivity and non-exhaustivity are intended for [future-proofing][12] a codebase, thus cannot be applied blindly everywhere, but rather wisely, where it may really has sense. That's why it's __very important__ to understand their __use-cases and implicability__ very well.
 
-For better understanding `#[non_exhaustive]` attribute purpose, design, limitations and use cases, read through the following articles:
+To better understand `#[non_exhaustive]` attribute's purpose, design, limitations and use cases, read through:
 - [Rust Reference: 7.6. The `non_exhaustive` attribute][9]
 - [Rust RFC 2008: `non_exhaustive`][10]
 - [Turreta: Using `#[non_exhaustive]` for Non-exhaustive Rust Structs][11]

--- a/2_idioms/2_6_sealing/README.md
+++ b/2_idioms/2_6_sealing/README.md
@@ -56,7 +56,7 @@ The main purpose of sealing a trait is, of course, [future-proofing][7] of [API]
 
 It's important to note that __trait sealing fully relies on__ tricking over visibility rules (__using a public [supertrait][8]__ or type, which __name is not publicly exported__), and so, has no impact on the type system semantics (a sealed public trait is just a regular public trait from the type system perspective). In theory, sealing a trait should affect its [coherence][9], by [relaxing its strictness for the use-cases which can never happen with a sealed trait][10]. However, that would require a special support by compiler, which seems [not gonna happen in the near future][11].
 
-For better understanding traits sealing, its design and use-cases, read through the following articles:
+To better understand traits sealing, its design and use-cases, read through:
 - [Rust API Guidelines: 10. Future proofing: Sealed traits protect against downstream implementations (C-SEALED)][3]
 - [Predrag Gruevski: A definitive guide to sealed traits in Rust][4]
 - [Jack Wrenn: Private Methods on a Public Trait][13]

--- a/3_ecosystem/3_10_threads/README.md
+++ b/3_ecosystem/3_10_threads/README.md
@@ -16,7 +16,7 @@ Traditionally, [threads][3] are used for solving [CPU-bound] problems, as they a
 
 [`crossbeam`] crate also provides implementation of [scoped threads][5], which allow to borrow values from a stack. They are also available in form of [`std::thread::scope`], as of [Rust] 1.63. 
 
-For better understanding [Rust] threads design, concepts, usage, and features (especially [TLS][4] is important and widely used one), read through the following articles:
+To better understand [Rust]'s threads design, concepts, usage, and features (especially [TLS][4] is important and widely used one), read through:
 - [Rust Book: 16.1. Using Threads to Run Code Simultaneously][6]
 - [Rust By Example: 20.1. Threads][7]
 - [Official `std::thread` docs][`std::thread`]
@@ -37,7 +37,7 @@ Threads communication is commonly represented via [channels][14] and is implemen
 
 Despite that, there is also the [`crossbeam`] crate, providing more feature-rich and optimized concurrency and synchronization primitives. The most notable is [`crossbeam-channel`] as [an enhancement][15] of `std` channel implementations.
 
-For better understanding and familiarity with [Rust] synchronization primitives design, concepts, usage, and features, read through the following articles:
+To better understand and be familiar with [Rust]'s synchronization primitives design, concepts, usage, and features, read through:
 - [Rust Book: 16.2. Using Message Passing to Transfer Data Between Threads][16]
 - [Rust Book: 16.3. Shared-State Concurrency][13]
 - [Rust Blog: Fearless Concurrency with Rust][2]
@@ -64,7 +64,7 @@ The important concept to understand is [how concurrency and parallelism differ][
 
 Another way to perform parallel data processing _without using [threads][3]_ is [SIMD] instructions usage. If an algorithm is parallelizable enough, applying [SIMD] instructions may [increase performance drastically][24]. [Rust] ecosystem provides basic support for [SIMD] instructions in a form of [`packed_simd`] crate.
 
-For better understanding and familiarity with parallelism in [Rust], read through the following articles:
+To better understand and be familiar with parallelism in [Rust], read through:
 - [Nicky Meuleman: Concurrent vs parallel][28]
 - [Official `rayon` crate docs][`rayon`]
 - [`rayon` crate FAQ][22]

--- a/3_ecosystem/3_11_async/README.md
+++ b/3_ecosystem/3_11_async/README.md
@@ -20,7 +20,7 @@ The basic primitive of async story in [Rust] is a [future abstraction][8] (also 
 
 [Rust] provides only basic trait definitions in the [`std::future`] module of its standard library. To use futures with all its power, consider to use the [`futures`] crate (and/or similar ones like [`futures-lite`], [`futures-time`], etc).
 
-To understand [Rust] futures concepts and design better, read through the following articles:
+To understand [Rust] futures concepts and design better, read through:
 - [Aaron Turon: Zero-cost futures in Rust][11]
 - [Aaron Turon: Designing futures for Rust][9]
 - [Rust RFC 2592: `futures_api`][13]
@@ -40,7 +40,7 @@ It's important to mention, that before [futures design has been stabilized][13],
 
 Though, [`async` keyword in not supported in trait methods yet][2], there is the [`async-trait`] crate, which allows this for traits by desugaring into a [`Box`]ed [`Future`] (the main downside of which is being non-transparent over auto-traits like `Send`/`Sync`). 
 
-For better understanding `async`/`.await` keywords design, desugaring, usage, and features, read through the following articles:
+To better understand `async`/`.await` keywords design, desugaring, usage and features, read through:
 - [Rust RFC 2394: `async_await`][16]
 - [Asynchronous Programming in Rust: 3. `async`/`.await`][21]
 - [Hayden Stainsby: how I finally understood async/await in Rust (part 1)][63]
@@ -58,7 +58,7 @@ Except the [future abstraction][8] itself, it's important to understand what is 
 When a task is suspended due to waiting some non-blocking operation to complete (it's used to call it "parked"), there should be a way to signal an executor to continue polling this task once the operation finishes. The [`Waker`] (being provided in the [`task::Context`]) serves exactly this purpose:
 > `Waker` provides a `wake()` method that can be used to tell the executor that the associated task should be awoken. When `wake()` is called, the executor knows that the task associated with the `Waker` is ready to make progress, and its future should be polled again.
 
-For better understanding [`Waker`] design, usage, and features, read through the following articles:
+To better understand [`Waker`]'s design, usage and features, read through:
 - [Official `std::task::Waker` docs][`Waker`]
 - [Asynchronous Programming in Rust: 2.2. Task Wakeups with `Waker`][22]
 - [Hayden Stainsby: how I finally understood async/await in Rust (part 2)][64]
@@ -91,7 +91,7 @@ The async programming is not possible without support for [non-blocking I/O][1],
 
 The low-level crates, like [`mio`] (powering [`tokio`]) and [`polling`] (powering [`async-std`]), provide a single multi-platform unified interface to the majority of those [API]s. There are also low-level crates, specialized on a concrete [API], like [`io-uring`].
 
-For better understanding, read through the following articles:
+To better understand this topic, read through:
 - [Official `mio` crate docs][`mio`]
 - [Official `polling` crate docs][`polling`]
 
@@ -113,7 +113,7 @@ Also, important to classify [Rust] asynchronous runtimes in the following manner
 
 Unfortunately, at the moment, there is no meaningful way to abstract over multiple asynchronous runtimes in [Rust]. That's why authors of the libraries using [non-blocking I/O][1] either stick with a single concrete runtime only ([`tokio`], mostly), or support multiple runtimes via [Cargo features][46].
 
-For better understanding, read through the following articles:
+To better understand this topic, read through:
 - [Official `tokio` crate docs][`tokio`]
 - [Official `async-std` crate docs][`async-std`]
 - [Tokio Tutorial][47]
@@ -149,7 +149,7 @@ The most famous [actors][49] implementation in [Rust] is [`actix`]. At the time 
 
 More general-purpose and complex [actors system][49] implementations (similar to [Akka]) are [`bastion`], [`riker`] and [`hydra`].
 
-For better understanding [actors][49] design, concepts, usage, and implementations, read through the following articles:
+To better understand [actors'][49] design, concepts, usage and implementations, read through:
 - [Karan Pratap Singh: CSP vs Actor model for concurrency][55]
 - [Official `actix` crate docs][`actix`]
 - [Official `actix` user guide][58]

--- a/3_ecosystem/3_1_testing/README.md
+++ b/3_ecosystem/3_1_testing/README.md
@@ -69,7 +69,7 @@ Additionally, [`mockito`] and [`wiremock`] crates should be mentioned as a quite
 
 The most powerful, however, is [`mockall`] crate. See [this overview][43] for more details.
 
-For better overview and familiarity with [mocking][41] in [Rust], read through the following articles:
+To better understand and be familiar with [mocking][41] in [Rust], read through:
 - [Alan Somers: Rust Mock Shootout!][43]
 - [Oduah Chigozie: Mocking in Rust: Mockall and alternatives][45]
 - [Official `mockall` crate docs][`mockall`]
@@ -88,7 +88,7 @@ For better overview and familiarity with [mocking][41] in [Rust], read through t
 
 [Rust] ecosystem has quite good [`proptest`] and [`quickcheck`] crates, which provide tools and primitives for [property testing][21].
 
-For better understanding and familiarity with [property testing][21] in [Rust], read through the following articles:
+To better understand and be familiar with [property testing][21] in [Rust], read through:
 - [`proptest` crate description][`proptest`]
 - [`quickcheck` crate description][`quickcheck`]
 - [Proptest Book][22]
@@ -105,7 +105,7 @@ For better understanding and familiarity with [property testing][21] in [Rust], 
 - [afl.rs] allows to run [AFL (american fuzzy lop)][AFL] on code written in [Rust].
 - [`honggfuzz`] is a security oriented fuzzer with powerful analysis options, which supports evolutionary, feedback-driven fuzzing based on code coverage (software- and hardware-based).
 
-For better understanding and familiarity with [fuzzing][31] in [Rust], read through the following articles:
+To better understand and be familiar with [fuzzing][31] in [Rust], read through:
 - [Rust Fuzz Book][34]
 - [Official `cargo-fuzz` crate docs][`cargo-fuzz`]
 - [Official `honggfuzz` crate docs][`honggfuzz`]

--- a/3_ecosystem/3_2_macro/README.md
+++ b/3_ecosystem/3_2_macro/README.md
@@ -37,7 +37,7 @@ The good part about declarative macros is that they are [hygienic][11] (and so, 
 
 Code generation purpose is not the only one declarative macros are used for. Quite often they are used for building abstractions and APIs too, because they all to implement much more ergonomic features than regular functions do: named arguments, [variadics][17], etc.
 
-For better understanding declarative macros design, concepts, usage and features, read through the following articles:
+To better understand declarative macros' design, concepts, usage and features, read through:
 - [Rust Book: 19.6. Macros: Declarative Macros with `macro_rules!` for General Metaprogramming][13]
 - [Rust By Example: 16. macro_rules!][14]
 - [The Little Book of Rust Macros][15]
@@ -103,7 +103,7 @@ On top of them, more ecosystem crates may be used for having less boilerplate, b
 - [`synstructure`] crate, providing helper types for matching against enum variants, and extracting bindings to each of the fields in the deriving struct or enum in a generic way.
 - [`synthez`] crate, providing [derive macros][29] for parsing [AST] (yeah, derive macros for derive macros!) and other helpful "batteries" for daily routine of procedural macro writing.
 
-For better understanding procedural macros design, concepts, usage and features, read through the following articles:
+To better understand procedural macros' design, concepts, usage and features, read through:
 - [Rust Book: 19.6. Macros: Procedural Macros for Generating Code from Attributes][23]
 - [Rust Reference: 3.2. Procedural Macros][26]
 - [Official `syn` crate docs][`syn`]

--- a/3_ecosystem/3_3_date_time/README.md
+++ b/3_ecosystem/3_3_date_time/README.md
@@ -9,7 +9,7 @@ The main difference between them (except the API, ergonomics and maintaining act
 
 If you hit limitations of [`time`] and [`chrono`] crates regarding their accuracy (like swallowing [leap seconds][3]) or supported formats/standards (like [TAI]), consider using the [`hifitime`] crate, representing a scientifically accurate and [formally verified][4] date and time library.
 
-For better understanding and familiarity, read through the following documentation:
+To better understand and be familiar with this topic, read through:
 - [Official `std::time` docs][`std::time`]
 - [Official `time` crate docs][`time`]
 - [Official `chrono` crate docs][`chrono`]

--- a/3_ecosystem/3_4_regex_parsing/README.md
+++ b/3_ecosystem/3_4_regex_parsing/README.md
@@ -59,7 +59,7 @@ If regular expressions are [not powerful enough][2] for your parsing problem, th
     - [`lalrpop`] crate, generating [LR(1) parser][6] code from custom grammar files.
     - [`parsel`] crate, a library for generating parsers directly from syntax tree node types.
 
-For better understanding parsing problem and approaches, along with some examples, read through the following articles:
+To better understand parsing problem and approaches, along with some examples, read through:
 - [Laurence Tratt: Which Parsing Approach?][9]
 - [Richard L. Apodaca: A Beginner's Guide to Parsing in Rust][10]
 - [Eshan Singh: Practical Parsing in Rust with nom][14]

--- a/3_ecosystem/3_5_collections/README.md
+++ b/3_ecosystem/3_5_collections/README.md
@@ -10,7 +10,7 @@ __Estimated time__: 1 day
 
 [Rust] provides [implementations for commonly used collections][`std::collections`] in its `std` library. They come with [different guarantees][2] and for [different purposes][1], and are usually applicable for 90% use cases.
 
-For better understanding [`std::collections`] purpose, design, limitations and use cases, read through the following articles:
+To better understand [`std::collections`]' purpose, design, limitations and use cases, read through:
 - [Rust Book: 8. Common Collections][5]
 - [Rust By Example: 19.2. Vectors][3]
 - [Rust By Example: 19.7. HashMap][4]
@@ -38,7 +38,7 @@ It's important to remember, that __iterators (and their adapters) are lazy__. [`
 
 [`Iterator`] comes with a lot of powerful and useful [adapters][9] in `std` library, which makes them highly composable and pleasant to use. If `std` capabilities are not enough for your needs, consider to use [`itertools`] crate, which provides more non-trivial adapters.
 
-For better understanding [Rust] iterators purpose, design, limitations and use cases, read through the following articles:
+To better understand [Rust] iterators' purpose, design, limitations and use cases, read through:
 - [Rust By Example: 16.4. Iterators][6]
 - [Official `std::iter` docs][`std::iter`]
 
@@ -51,7 +51,7 @@ For better understanding [Rust] iterators purpose, design, limitations and use c
 
 [Rust] ecosystem has [`im`] and [`rpds`] crates, which provide immutable implementations for some collections.
 
-For better understanding immutable collections' nature, design, and a motivation behind them, read through the following articles:
+To better understand immutable collections' nature, design, and a motivation behind them, read through:
 - [Official `im` crate docs][`im`]
 - [Wikipedia: Persistent data structure][10]
 - [Jean Niklas L'orange: Understanding Clojure's Persistent Vectors, pt. 1][15_1]
@@ -67,7 +67,7 @@ When you need to operate with the same collection from multiple threads, the mos
 
 [Rust] ecosystem has [`crossbeam`] and [`lockfree`] crates, providing efficient lock-free implementations for some collections usually used in a concurrent context. Also, consider [`flurry`] and [`chashmap`] crates for a concurrent [hash map][`HashMap`] implementation.
 
-For better understanding concurrent collections' nature, design, and a motivation behind them, read through the following articles:
+To better understand concurrent collections' nature, design, and a motivation behind them, read through:
 - [Aaron Turon: Lock-freedom without garbage collection][13]
 - [Stjepan Glavina: Lock-free Rust: Crossbeam in 2019][14]
 - [Wikipedia: Non-blocking algorithm][12]

--- a/3_ecosystem/3_6_serde/README.md
+++ b/3_ecosystem/3_6_serde/README.md
@@ -34,7 +34,7 @@ fn main() {
 
 [`serde`] by itself represents only a universal serialization frontend, which can be backed by actual implementation for any format. There are already [implemented backends for most used formats][2], and you're free to [implement backend for your own format][3] if it's not implemented yet. 
 
-For better understanding and familiarity with [`serde`]'s design, concepts, usage, and features (like [zero-copy deserialization][5]), read through the following articles:
+To better understand and be familiar with [`serde`]'s design, concepts, usage and features (like [zero-copy deserialization][5]), read through:
 - [Official `serde` crate guide][0]
 - [Official `serde` crate docs][`serde`]
 - [Official `serde_json` crate docs][`serde_json`]
@@ -105,7 +105,7 @@ However, the __main "killer feature"__ of [`musli`] is its __ability to serializ
 > assert_eq!(out, r#"["あります",true]"#);
 > ```
 
-For better understanding and familiarity with [`musli`]'s design, concepts, usage, and features, read through the following articles:
+To better understand and be familiar with [`musli`]'s design, concepts, usage and features, read through:
 - [Official `musli` crate docs][`musli`]
 - [John-John Tedro: A fresh look on incremental zero copy serialization][23]
 
@@ -122,7 +122,7 @@ For better understanding and familiarity with [`musli`]'s design, concepts, usag
 
 > While rkyv is a great format for final data, it lacks a full schema system and isn’t well equipped for data migration and schema upgrades. If your use case requires these capabilities, you may need additional libraries the build these features on top of rkyv. You can use other serialization frameworks like serde with the same types as rkyv conflict-free.
 
-For better understanding and familiarity with [`rkyv`]'s design, concepts, usage, and features, read through the following articles:
+To better understand and be familiar with [`rkyv`]'s design, concepts, usage and features, read through:
 - [Official `rkyv` crate docs][`rkyv`]
 - [`rkyv` book][30]
 

--- a/3_ecosystem/3_8_log/README.md
+++ b/3_ecosystem/3_8_log/README.md
@@ -17,7 +17,7 @@ __Estimated time__: 1 day
 
 One interesting part is that log levels can be [disabled at compile time][3], thus have __no runtime performance impact at all__, unless you're debugging.
 
-For better understanding and familiarity with [`log`]'s design, concepts, usage, and features, read through the following articles:
+To better understand and be familiar with [`log`]'s design, concepts, usage and features, read through:
 - [Official `log` crate docs][`log`]
 - [Jimmy Hartzell: Using the Log Crate in Your Rust Projects][12]
 
@@ -32,7 +32,7 @@ For [structured logging][4] there is the excellent [`slog`] crate in [Rust] ecos
 
 It's __backward and forward compatible with [`log`]__ crate, extending its ideas and is baked with an [excellent performance][5].
 
-For better understanding and familiarity with [`slog`]'s design, concepts, usage, and features, read through the following articles:
+To better understand and be familiar with [`slog`]'s design, concepts, usage and features, read through:
 - [Official `slog` crate docs][`slog`]
 - [Official `slog` crate wiki][6]
 
@@ -49,7 +49,7 @@ Its "killer feature", undoubtedly, is [spans functionality][7], so [people tend 
 
 Speaking of [tracing][10], the [`tracing`] crate has good integrations with [OpenTelemetry]-compatible distributed tracing systems (and similar ones). All this allows to reuse the same solution both for logging, tracing (like [Jaeger], [Zipkin]), profiling (like [coz], [Tracy]), error reporting (like [Sentry]), etc.
 
-For better understanding and familiarity with [`tracing`]'s design, concepts, usage, and features, read through the following articles:
+To better understand and be familiar with [`tracing`]'s design, concepts, usage and features, read through:
 - [Official `tracing` crate docs][`tracing`]
 - [Joshua Mo: Getting Started with Tracing in Rust][13]
 - [Yoav Danieli: Guide to OpenTelemetry Distributed Tracing in Rust][11]

--- a/3_ecosystem/3_9_cmd_env_conf/README.md
+++ b/3_ecosystem/3_9_cmd_env_conf/README.md
@@ -14,7 +14,7 @@ However, most of the time you require more advanced tool for that, which provide
 
 It has the [`derive` Cargo feature][6] (formerly, [`structopt`] crate) allowing to define [CLI] in a _declarative and clean way_.
 
-For better understanding and familiarity with [CLI] tools in [Rust] ecosystem, read through the following articles:
+To better understand and be familiar with [CLI] tools in [Rust] ecosystem, read through:
 - [Rust Book: 12.1. Accepting Command Line Arguments][1]
 - [Official `std::env::Arg` docs][`std::env::Arg`]
 - [Official `clap` crate docs][`clap`]
@@ -33,7 +33,7 @@ It's worth mentioning, that [`clap`] crate is [able to parse from environment va
 
 Finally, [`dotenv`] crate should be mentioned. It sets [environment variables][2] basing on [`.env` file][8] contents, which is widely used convention to simplify environment configuration and to omit declaring all the required environment variables by hand each time when running some program. This one is especially _useful in development_ (consider also [`rs-env`] and [`direnv`] for better development experience).
 
-For better understanding and familiarity with [environment variables][2] tools in [Rust] ecosystem, read through the following articles:
+To better understand and be familiar with [environment variables][2] tools in [Rust] ecosystem, read through:
 - [Rust Book: 12.5. Working with Environment Variables][3]
 - [Official `std::env` docs][`std::env`]
 - [Official `envy` crate docs][`envy`]
@@ -58,7 +58,7 @@ For dealing with configurations there is the well-known [`config`] crate in [Rus
 > - Deep access into the merged configuration via a path syntax
 > - Deserialization via `serde` of the configuration or any subset defined via a path
 
-For better understanding and familiarity with [`config`] crate design, concepts, usage, and features, read through the following articles:
+To better understand and be familiar with [`config`] crate's design, concepts, usage and features, read through:
 - [Official `config` crate docs][`config`]
 - [`config` crate examples][5]
 

--- a/4_backend/4_1_db/README.md
+++ b/4_backend/4_1_db/README.md
@@ -14,7 +14,7 @@ The important concept to understand is a [connection pool][11] pattern. It's wid
 
 Fortunately, [Rust] ecosystem provides generic implementations of database-agnostic [connection pool][1] in both flavours: synchronous and asynchronous.
 
-For better understanding [connection pooling][1], read through the following articles:
+To better understand [connection pooling][1], read through:
 - [Charlie Custer: What is Connection Pooling, and Why Should You Care][15]
 
 
@@ -22,7 +22,7 @@ For better understanding [connection pooling][1], read through the following art
 
 For synchronous connections there is the [`r2d2`] crate (the pioneer among such crates, existed far before [async I/O][3] has landed in [Rust]). You can easily adopt it for your specific use-case (or database) just by implementing [its traits][22]. Obviously, there are [implementations for common drivers][21] already.
 
-For more details, read through the following articles:
+For more details, read through:
 - [Official `r2d2` crate docs][`r2d2`]
 
 
@@ -38,7 +38,7 @@ Another alternative implementation is the [`mobc`] crate, yet inspired by [`dead
 
 [`qp`] (Quick Pool) is a very simple and [limited][29] implementation of the [connection pool][11] pattern, [utilizing lock-free primitives][27] and [focused on being performant][28].
 
-For more details, read through the following articles:
+For more details, read through:
 - [Official `bb8` crate docs][`bb8`]
 - [Official `deadpool` crate docs][`deadpool`]
 - [Official `mobc` crate docs][`mobc`]
@@ -55,7 +55,7 @@ The canonical implementation of this pattern in [Rust] ecosystem is represented 
 
 [`barrel`] crate, on the other hand, allows to write [schema migrations][61], rather than querying data.
 
-For more details, read through the following articles:
+For more details, read through:
 - [Official `sea-query` crate docs][`sea-query`]
 - [Official `sql_query_builder` crate docs][`sql_query_builder`]
 - [Official `barrel` crate docs][`barrel`]
@@ -65,7 +65,7 @@ For more details, read through the following articles:
 
 [`sqlx`] crate, while being a feature-rich toolkit for [SQL], takes a [completely opposite approach][91] here: it focuses on writing pure [SQL] queries (no custom [DSL], no [query building](#query-builder)), which are statically checked to be correct at compile-time.
 
-For better understanding [`sqlx`] design, concepts, usage, and features, read through the following articles:
+To better understand [`sqlx`]'s design, concepts, usage and features, read through:
 - [Official `sqlx` crate docs][`sqlx`]
 
 
@@ -83,7 +83,7 @@ The very first [ORM][41] created in [Rust] was the [`diesel`] crate. Even now, i
 
 [`rustorm`] is a very simple and [SQL]-centered [ORM][41], focused on easing conversions of database types to their appropriate [Rust] types.
 
-For better understanding [ORMs][41] design, concepts, usage, and features, read through the following articles:
+To better understand [ORMs'][41] design, concepts, usage and features, read through:
 - [Official `diesel` crate docs][`diesel`]
 - [Official `diesel` crate guides][44]
 - [Official `sea-orm` crate docs][`sea-orm`]
@@ -104,7 +104,7 @@ For [`sqlx`] users, similarly, the [`sqlx-cli`] tool [provides migrations][64] o
 
 [`refinery`] and [`migrant`] are another standalone [Rust] tools for [migrations][61], allowing both [CLI] and ["in-application-code"][66] usage. The interesting part about the [`refinery`] crate is that it also allows to write "in-application-code" [migrations][61] via the [`barrel`] schema migration builder.
 
-For being familiar with [migrations][61] tools, their similarities and differences, read through the following articles:
+To be familiar with [migrations][61] tools, their similarities and differences, read through:
 - [Official `diesel_migrations` crate docs][`diesel_migrations`]
 - [Official `diesel_cli` crate docs][`diesel_cli`]
 - [Official `diesel` crate guides: Getting Started][63]

--- a/4_backend/4_2_http/README.md
+++ b/4_backend/4_2_http/README.md
@@ -18,7 +18,7 @@ The main alternatives are:
 - [`async-h1`], powering the [`async-std`] ecosystem for [HTTP].
 - [`actix-http`], powering the [`actix-web`] ecosystem.
 
-For more details, read through the following articles:
+For more details, read through:
 - [Official `hyper` crate docs][`hyper`]
 - [Official `async-h1` crate docs][`async-h1`]
 - [Official `actix-http` crate docs][`actix-http`]
@@ -39,7 +39,7 @@ For those who prefer [`async-std`] ecosystem, the definitive choice (and the sin
 
 All the [web frameworks][21] above inherit the [work-stealing][23] from the asynchronous runtime they're run on, and so, require the proper synchronization (being [`Send`]) from user-provided [HTTP] request handlers, which may introduce an unnecessary or undesired overhead. That's why __[`actix-web`] crate was designed__ and implemented specifically with this consideration in mind (__to avoid [work-stealing][23]__), being built on top of [`actix-rt`] crate (leveraging [thread-per-core][24] model), and thus, not requiring any synchronization in its request handlers (allowing `!Send` [`Future`]s). Also, [`actix-web`], at the time, was the first mature and production-ready [web framework][21] in [Rust] ecosystem, possessing a [top of "TechEmpower Web Framework Benchmarks"][25].
 
-For better understanding and familiarity with [HTTP] servers in [Rust], read through the following articles:
+To better understand and be familiar with [HTTP] servers in [Rust], read through:
 - [Official `actix-web` crate docs][`actix-web`]
 - [Official `actix-web` crate guides: Server](https://actix.rs/docs/server)
 - [Official `axum` crate docs][`axum`]
@@ -65,7 +65,7 @@ For [`async-std`] ecosystem, the main crate is [`surf`], which is, however, not 
 
 For [`actix-web`] ecosystem, the meaningful option would be the [`awc`] crate, which supports [WebSocket] connections out-of-the-box (while most other [HTTP] clients lacks that).
 
-For better understanding and familiarity with [HTTP] clients in [Rust], read through the following articles:
+To better understand and be familiar with [HTTP] clients in [Rust], read through:
 - [Official `reqwest` crate docs][`reqwest`]
 - [Joshua Mo: Writing a Web Scraper in Rust using Reqwest][33]
 - [Official `isahc` crate docs][`isahc`]
@@ -83,7 +83,7 @@ Many [HTTP] clients and servers in [Rust] lack a built-in [WebSocket] implementa
 
 For [`actix-web`] ecosystem, the idiomatic solution is the [`actix-web-actors::ws`] module, providing implementation in a form of [actor][41] (via [`actix`]).
 
-For better understanding and familiarity with [WebSocket] implementations in [Rust], read through the following articles:
+To better understand and be familiar with [WebSocket] implementations in [Rust], read through:
 - [Official `tungstenite` crate docs][`tungstenite`]
 - [Official `async-tungstenite` crate docs][`async-tungstenite`]
 - [Official `tokio-tungstenite` crate docs][`tokio-tungstenite`]

--- a/4_backend/4_3_api/README.md
+++ b/4_backend/4_3_api/README.md
@@ -16,7 +16,7 @@ Since [REST] is rather an __architecture convention/style__ than a strict [speci
 
 This approach, however, __suffers from lacking [API] schema__, and so, makes it hard to build a rich ecosystem around with ready-to-use tooling (or connect with existing ones). Fortunately, this is easily solved by using a concrete [RPC specification][3] on top of [REST] conventions, and following it strictly. 
 
-For more information about [REST], read through the following articles:
+For more information about [REST], read through:
 - [Tyler Charboneau: What’s the Difference Between RPC and REST?][111]
 
 
@@ -32,7 +32,7 @@ In [Rust] ecosystem, most [OpenAPI] crates follow the __code-first approach__ (g
 
 For the opposite (generating source code from [OpenAPI] schema) [Rust] ecosystem lacks its own pure implementation, and the original [OpenAPI] tool [`openapi-generator`] should be used (powered by the [`swagger`] crate).
 
-For more familiarity with [OpenAPI] and using it in [Rust], read through the following articles:
+To be familiar with [OpenAPI] and using it in [Rust], read through:
 - [OpenAPI Initiative]
 - [SwaggerHub Documentation: OpenAPI 3.0 Tutorial][122]
 - [Official `utoipa` crate docs][`cynic`]
@@ -54,7 +54,7 @@ One of the strongest parts of [GraphQL] is its [whole ecosystem][203] built arou
 
 Another strong part of [GraphQL] is that its __protocol is [transport][204]-agnostic__, so the same schema and queries, used via [HTTP], are __easily reusable via [WebSocket]__, allowing to [stream data][205] with almost zero effort atop.
 
-For more familiarity with [GraphQL], read through the following articles:
+To be familiar with [GraphQL], read through:
 - [GraphQL docs: Introduction to GraphQL][206]
 - [The Fullstack Tutorial for GraphQL][207]
 
@@ -65,7 +65,7 @@ For implementing a [GraphQL] server in [Rust], there are two major crates in its
 
 [`juniper-from-schema`] crate, however, tries to take it in opposite direction, and to some degree successfully __provides schema-to-code approach__ (generating [Rust] code using [`juniper`] from a provided [GraphQL] schema).
 
-For more familiarity with implementing [GraphQL] server in [Rust], read through the following articles:
+To be familiar with implementing [GraphQL] server in [Rust], read through:
 - [Official `juniper` crate docs][`juniper`]
 - [Juniper Book]
 - [Official `juniper-from-schema` crate docs][`juniper-from-schema`]
@@ -81,7 +81,7 @@ However, if more static guarantees is needed, then the [`graphql-client`] crate 
 
 [`cynic`] crate takes the __opposite code-to-query approach__ of generating a [GraphQL] query out of [Rust] code and validating it statically against a provided [GraphQL] schema.
 
-For more familiarity with making [GraphQL] requests in [Rust], read through the following articles:
+To be familiar with making [GraphQL] requests in [Rust], read through:
 - [Official `graphql-client` crate description][`graphql-client`]
 - [Official `cynic` crate docs][`cynic`]
 - [Official `cynic` crate guide](https://cynic-rs.dev)
@@ -93,7 +93,7 @@ For more familiarity with making [GraphQL] requests in [Rust], read through the 
 
 [gRPC] is a widely-adopted high performance [RPC] framework, having a __strict schema__, powered with pluggable support for load balancing, tracing, health checking and authentication, built on top of [HTTP/2] (and so, having a __mandatory encryption__), and __heavily using code-from-schema generation__.
 
-For more familiarity with [gRPC], read through the following articles:
+To be familiar with [gRPC], read through:
 - [gRPC docs: Introduction to gRPC][301]
 - [gRPC docs: Core concepts, architecture and lifecycle][302]
 
@@ -104,7 +104,7 @@ For implementing a [gRPC] server in [Rust], there are two main production-ready 
 
 In [gRPC] ecosystem, usually, implementing a [gRPC] client doesn't differ much from implementing a server, since both are auto-generated from the same `.proto` schema. So, for [Rust], the same [`tonic`] and [`grpcio`] crates do the job when it comes to making [gRPC] requests. 
 
-For more familiarity with using [gRPC] in [Rust], read through the following articles:
+To be familiar with using [gRPC] in [Rust], read through:
 - [Official `tonic` crate docs][`tonic`]
 - [Official `grpcio` crate docs][`grpcio`]
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This project represents a hard-way step-by-step [Rust] learning course from lang
 
 ### Toolchain
 
-- [rustup] for installing [Rust] toolchain and keeping it up-to-date.
-- [CLion]/[IntelliJ IDEA] + [IntelliJ Rust] + [Toml][IntelliJ Toml] plugins as development environment (or any other on your choice).
+- [rustup] for installing the [Rust] toolchain and keeping it up-to-date.
+- [CLion]/[IntelliJ IDEA] + [IntelliJ Rust] + [Toml][IntelliJ Toml] plugins as the development environment (or any other of your choice).
 
 
 ### Bookshelf
@@ -24,19 +24,19 @@ This project represents a hard-way step-by-step [Rust] learning course from lang
 - [Rust By Example] teaches you [Rust] basics using editable examples.
 - [Rust Reference] is not a formal spec, but is more detailed and comprehensive than the [Rust Book].
 - [Cheats.rs] and [Rust SVG Cheatsheet] for quick reference.
-- [Rust Edition Guide] for considering improvements of [Rust 2018] and [Rust 2021].
+- [Rust Edition Guide] for considering the improvements in [Rust 2018] and [Rust 2021].
 - [Rust std lib] documentation.
 - [Cargo Book] is a guide to [Cargo], [Rust]'s build tool and dependency manager.
-- [Rustdoc Book] is a guide to `rustdoc` documentation tool.
-- [Rust Cookbook] is a collection of simple examples that demonstrate good practices to accomplish common programming tasks, using the crates of the [Rust] ecosystem.
+- [Rustdoc Book] is a guide to the `rustdoc` documentation tool.
+- [Rust Cookbook] is a collection of simple examples that demonstrate good practices to accomplish common programming tasks, using crates from the [Rust] ecosystem.
 - [Rust Design Patterns] is an open source repository of [Rust] design patterns and idioms.
 - [Effective Rust] is a collection of guidelines that had been learned from real world experience of creating software in [Rust].
 - [Rust API Guidelines] is a set of recommendations on how to design and present APIs for [Rust].
-- [Rust FAQ] answers common question about [Rust].
-- [Rust Playground] allows to share and check runnable [Rust] code snippets online.
+- [Rust FAQ] answers common questions about [Rust].
+- [Rust Playground] allows sharing and checking runnable [Rust] code snippets online.
 - [Awesome Rust] is a curated list of [Rust] code and resources.
 - [This Week in Rust] represents handpicked and subscribable [Rust] weekly updates.
-- [Baby Steps] blog of [Nicholas Matsakis](https://github.com/nikomatsakis) shares useful [Rust] patterns, ideas and design decisions.
+- [Baby Steps] blog by [Nicholas Matsakis](https://github.com/nikomatsakis) shares useful [Rust] patterns, ideas and design decisions.
 - [Learning Material for Idiomatic Rust] is a curated list of resources to help you write ergonomic and idiomatic [Rust] code.
 
 
@@ -47,7 +47,7 @@ This project represents a hard-way step-by-step [Rust] learning course from lang
 
 ### Before you start
 
-[Create][1] a new [GitHub repository] for yourself using this one [as template][11].
+[Create][1] a new [GitHub repository] for yourself using this one [as a template][11].
 
 > __NOTE__: __This learning course is constantly improving and evolving over time.__ 
 >
@@ -67,7 +67,7 @@ This project represents a hard-way step-by-step [Rust] learning course from lang
 
 ### Schedule
 
-Each step must be performed as a separate [PR (pull request)][PR] with an appropriate name and check-marked here in README's schedule after completion. Each step is a [Cargo workspace member][13], so you can run/test it from the project root (i.e. `cargo run -p step_1_8`). __Consider to use [rustfmt] and [Clippy] when you're writing [Rust] code.__
+Each step must be performed as a separate [PR (pull request)][PR] with an appropriate name and check-marked here in the README's schedule after completion. Each step is a [Cargo workspace member][13], so you can run/test it from the project root (i.e. `cargo run -p step_1_8`). __Consider using [rustfmt] and [Clippy] when you're writing [Rust] code.__
 
 - [ ] [0. Become familiar with Rust basics][Step 0] (3 days)
 - [ ] [1. Concepts][Step 1] (2 days, after all sub-steps)
@@ -109,9 +109,9 @@ Each step must be performed as a separate [PR (pull request)][PR] with an approp
 
 ## More practice
 
-- [rustlings] are small exercises to get you used to reading and writing [Rust] code.
+- [Rustlings][rustlings] is a collection of small exercises to get you used to reading and writing [Rust] code.
 - [Rust on Exercism] provides coding exercises with mentoring.
-- [Rust Quiz] is medium to hard [Rust] questions with explanations.
+- [Rust Quiz] for medium to hard [Rust] questions with explanations.
 
 
 


### PR DESCRIPTION
Resolves #18 




## Synopsis

There are grammatical issues in the READMEs.


## Solution

Fixed some grammatical mistakes in the root README, along with the READMEs for Step 0, Step 1.1, and Step 1.2.

I tried to make the changes as objective as possible, but language is inherently somewhat of a subjective thing, and I may have misunderstood something. Things that seemed ambiguous to me were kept as is.